### PR TITLE
Convert to Nix flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: cachix/install-nix-action@v22
-      with:
-        nix_path: nixpkgs=channel:nixos-23.05
 
-    # build without systemd support for now, since the closure becomes larger
-    - run: nix-build --arg withSystemd false
+    - run: nix build
+    - run: nix flake check
 
     - name: Prepare artifacts
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: cachix/install-nix-action@v22
+    - uses: cachix/install-nix-action@v24
 
     - run: nix build --no-update-lock-file
     - run: nix flake check --no-update-lock-file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
 
     - uses: cachix/install-nix-action@v22
 
-    - run: nix build
-    - run: nix flake check
+    - run: nix build --no-update-lock-file
+    - run: nix flake check --no-update-lock-file
 
     - name: Prepare artifacts
       run: |

--- a/build.nix
+++ b/build.nix
@@ -1,8 +1,6 @@
-{ pkgs ? import <nixpkgs> {}, withSystemd ? true }:
+{ pkgs, ttRss, withSystemd ? true }:
 
 let
-
-  ttRss = (import ./tt-rss.nix { inherit pkgs; });
 
   php = (pkgs.php.override {
     embedSupport = true;

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677179781,
-        "narHash": "sha256-+peLp16ruWLuTFHo0ZUbLlS1/meS/+RsWQQ9bUAzOh8=",
+        "lastModified": 1702233072,
+        "narHash": "sha256-H5G2wgbim2Ku6G6w+NSaQaauv6B6DlPhY9fMvArKqRo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50c23cd4ff6c8344e0b4d438b027b3afabfe58dd",
+        "rev": "781e2a9797ecf0f146e81425c822dca69fe4a348",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677179781,
+        "narHash": "sha256-+peLp16ruWLuTFHo0ZUbLlS1/meS/+RsWQQ9bUAzOh8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50c23cd4ff6c8344e0b4d438b027b3afabfe58dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = ''Portable "Tiny Tiny Rss" service run by uwsgi-php and built with Nix'';
 
-  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-22.11;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-23.11;
 
   outputs = { self, nixpkgs, ... }:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,6 @@
       pkgs = import nixpkgs { system = "x86_64-linux"; };
       ttRss = (import ./tt-rss.nix { inherit pkgs; });
     in {
-      packages.x86_64-linux.default = (import ./build.nix { inherit pkgs ttRss; });
+      packages.x86_64-linux.default = (import ./build.nix { inherit pkgs ttRss; withSystemd = false; });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = ''Portable "Tiny Tiny Rss" service run by uwsgi-php and built with Nix'';
+
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-22.11;
+
+  outputs = { self, nixpkgs, ... }: rec {
+    pkgs = import nixpkgs { system = "x86_64-linux"; };
+    ttRss = (import ./tt-rss.nix { inherit pkgs; });
+
+    packages.x86_64-linux.default = (import ./build.nix { inherit pkgs ttRss; });
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,11 @@
 
   inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-22.11;
 
-  outputs = { self, nixpkgs, ... }: rec {
-    pkgs = import nixpkgs { system = "x86_64-linux"; };
-    ttRss = (import ./tt-rss.nix { inherit pkgs; });
-
-    packages.x86_64-linux.default = (import ./build.nix { inherit pkgs ttRss; });
-  };
+  outputs = { self, nixpkgs, ... }:
+    let
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+      ttRss = (import ./tt-rss.nix { inherit pkgs; });
+    in {
+      packages.x86_64-linux.default = (import ./build.nix { inherit pkgs ttRss; });
+    };
 }


### PR DESCRIPTION
https://nixos.wiki/wiki/Flakes

"Flakes" don't assume impure global nixpkgs, rather refer to them directly via the combination of `inputs` in `flake.nix` and the `flake.lock` file.

- `default.nix` renamed to `build.nix` with minimal changes
- the import of `tt-rss.nix` was moved into the flake 

github action changes:
- bump to v24
- no need for nix_path, since the flake refers to the exact `nixpkgs`
- added `flake check`
- flakes are automatically supported by the action, so no changes were required